### PR TITLE
Adding new ref_type for lemmas which are names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 >>> from index import add_to_index
 >>> add_to_index('Grundriß', 'ZW', '79')
 >>> add_to_index('Grundriß', 'GA 79', '8-9', 'r') # Not exact term, but related discussion
+>>> add_to_index('Kierkegaard, Søren' , 'GA 29/30', '226', 'p') # Referencing personal names
 ```
 
 ## References

--- a/heidegger-index.yml
+++ b/heidegger-index.yml
@@ -16,6 +16,10 @@ Geviert:
     reftype: r
   ZW:
   - pageref: '79'
+"Kierkegaard, S\xF8ren":
+  GA 29/30:
+  - pageref: '226'
+  reftype: p
 Langeweile:
   EWI:
   - pageref: '39'
@@ -27,6 +31,11 @@ Maschine:
 Natur:
   EWI:
   - pageref: 41ff.
+Novalis:
+  GA 29/30:
+  - pageref: '7'
+  - pageref: 10-12
+  reftype: p
 Tod:
   EWI:
   - pageref: '18'

--- a/index.py
+++ b/index.py
@@ -9,13 +9,19 @@ def add_to_index(lemma, work, page_ref, ref_type=None):
         index = yaml.load(f)
 
     reference = {'pageref': page_ref}
-    if ref_type:
-        reference['reftype'] = ref_type
+
+    # Makes sure ref_type 'p' is a child of 'lemma' instead of 'work'
+    if ref_type is not 'p' and ref_type is not None:
+         reference['reftype'] = ref_type
 
     try:
         lemma_entry = index[lemma]
     except KeyError:
-        lemma_entry = {work: [reference]}
+        # Makes sure ref_type 'p' is a child of 'lemma' instead of 'work'
+        if ref_type != 'p':
+            lemma_entry = {'reftype': ref_type, work: [reference]}
+        else:
+            lemma_entry = {work: [reference]}
     else:
         try:
             lemma_entry[work].append(reference)

--- a/index.py
+++ b/index.py
@@ -11,15 +11,16 @@ def add_to_index(lemma, work, page_ref, ref_type=None):
     reference = {'pageref': page_ref}
 
     # Makes sure ref_type 'p' is a child of 'lemma' instead of 'work'
-    if ref_type is not 'p' and ref_type is not None:
+    if ref_type != 'p' and ref_type != None:
          reference['reftype'] = ref_type
 
     try:
         lemma_entry = index[lemma]
     except KeyError:
         # Makes sure ref_type 'p' is a child of 'lemma' instead of 'work'
-        if ref_type != 'p':
-            lemma_entry = {'reftype': ref_type, work: [reference]}
+        if ref_type == 'p':
+            lemma_entry = {work: [reference]}
+            lemma_entry['reftype'] = ref_type
         else:
             lemma_entry = {work: [reference]}
     else:

--- a/references.yml
+++ b/references.yml
@@ -40,6 +40,27 @@ SZ:
   publisher-place: Frankfurt am Main
   title: Sein und Zeit
   type: book
+"GA 29/30":
+  author:
+  - family: Heidegger
+    given: Martin
+  collection-editor:
+  - family: Klostermann
+    given: Vittorio
+  collection-number: 'band 29/30'
+  collection-title: Gesamtausgabe
+  editor:
+  - family: Hermann
+    given: Friedrich-Wilhelm
+    non-dropping-particle: von
+  id: 'GA 29/30'
+  issued:
+    date-parts:
+    - - '1983'
+  publisher: Vittorio Klostermann
+  publisher-place: Frankfurt am Main
+  title: "Die Grundbegriffe der Metaphysik : Welt, Endlichkeit, Einsamkeit"
+  type: book
 VA:
   author:
   - family: Heidegger


### PR DESCRIPTION
Add ref_type = 'p' for Lemmas which are personal names.

When adding a lemma with a ref_type equal to 'p', the ref_type is a child of the lemma instead of a child of pageref. This is because the whole lemma is ofcourse a personal name.

This will make it easier to render seperate indices for names and terms later on. 

(Also added GA 29/30 to references.yml)