### PR TITLE
Fix issue #5 plus error messages if reftype does not match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ add-ref --help
 Usage: add-ref [OPTIONS] LEMMA WORK REF
 
 Options:
-  -t, --type [p|w]  Type of lemma (p: person, w: work, r: related term)
+  -t, --type [p|w]  Type of lemma (p: person, w: work)
   --help            Show this message and exit.
 ```
 


### PR DESCRIPTION
1. Fix issue #5: reftype 'w' is now a child of lemma, instead of being part of the reference.
2. Added error messages if reftype given does not match the one already assigned to the lemma in the index.