### PR TITLE
Feature/work page seperate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ A Django project is included with models into which `index/heidegger-index.yml` 
 3. Populate the database:
 
    ```sh
-   python manage.py populate
+   python manage.py populate_index
    ```
 
 4. Spin up the django project:

--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -51,6 +51,10 @@ class Lemma(models.Model):
         else:
             return SafeString(format_string)
 
+    def format_just_lemma(self):
+        format_string = f"<i>{self.value}</i>"
+        return SafeString(format_string)
+
     def create_sort_key(self):
         self.sort_key = gen_sort_key(self.value)
 

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -19,25 +19,27 @@
     {% endif %}
   {% endfor %}
 </ul>
-<h3>People mentioned</h3>
-<ul class="lemma-refs">
-  {% for lemma, page_ref_list in lemma_list %}
-    {% if lemma.type == 'p' %}
+{% if person_list %}
+  <h3>People mentioned</h3>
+  <ul class="lemma-refs">
+    {% regroup person_list by lemma as person_list %}
+    {% for lemma, page_ref_list in person_list %}
       <li>
         <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format_just_lemma }}</a>: {{ page_ref_list|join:', ' }}
       </li>
-    {% endif %}
-  {% endfor %}
-</ul>
-<h3>Works mentioned</h3>
-<ul class="lemma-refs">
-  {% for lemma, page_ref_list in lemma_list %}
-    {% if lemma.type == 'w' %}
+    {% endfor %}
+  </ul>
+{% endif %}
+{% if work_list %}
+  <h3>Works mentioned</h3>
+  <ul class="lemma-refs">
+    {% regroup work_list by lemma as work_list %}
+    {% for lemma, page_ref_list in work_list %}
       <li>
         <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format_just_lemma }}</a>: {{ page_ref_list|join:', ' }}
       </li>
-    {% endif %}
-  {% endfor %}
-</ul>
+    {% endfor %}
+  </ul>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -12,9 +12,31 @@
 {% regroup page_refs by lemma as lemma_list %}
 <ul class="lemma-refs">
   {% for lemma, page_ref_list in lemma_list %}
-    <li>
-      <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
-    </li>
+    {% if not lemma.type %}
+      <li>
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>
+<h2>People mentioned</h2>
+<ul class="lemma-refs">
+  {% for lemma, page_ref_list in lemma_list %}
+    {% if lemma.type == 'p' %}
+      <li>
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>
+<h2>Works mentioned</h2>
+<ul class="lemma-refs">
+  {% for lemma, page_ref_list in lemma_list %}
+    {% if lemma.type == 'w' %}
+      <li>
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+      </li>
+    {% endif %}
   {% endfor %}
 </ul>
 {% endif %}

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -14,7 +14,7 @@
   {% for lemma, page_ref_list in lemma_list %}
     {% if not lemma.type %}
       <li>
-        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format_just_lemma }}</a>: {{ page_ref_list|join:', ' }}
       </li>
     {% endif %}
   {% endfor %}
@@ -24,7 +24,7 @@
   {% for lemma, page_ref_list in lemma_list %}
     {% if lemma.type == 'p' %}
       <li>
-        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format_just_lemma }}</a>: {{ page_ref_list|join:', ' }}
       </li>
     {% endif %}
   {% endfor %}
@@ -34,7 +34,7 @@
   {% for lemma, page_ref_list in lemma_list %}
     {% if lemma.type == 'w' %}
       <li>
-        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format }}</a>: {{ page_ref_list|join:', ' }}
+        <a href="{% url 'index:lemma-detail' lemma.slug %}" class="hidden-link">{{ lemma.format_just_lemma }}</a>: {{ page_ref_list|join:', ' }}
       </li>
     {% endif %}
   {% endfor %}

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -19,7 +19,7 @@
     {% endif %}
   {% endfor %}
 </ul>
-<h2>People mentioned</h2>
+<h3>People mentioned</h3>
 <ul class="lemma-refs">
   {% for lemma, page_ref_list in lemma_list %}
     {% if lemma.type == 'p' %}
@@ -29,7 +29,7 @@
     {% endif %}
   {% endfor %}
 </ul>
-<h2>Works mentioned</h2>
+<h3>Works mentioned</h3>
 <ul class="lemma-refs">
   {% for lemma, page_ref_list in lemma_list %}
     {% if lemma.type == 'w' %}

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -23,6 +23,8 @@ class WorkDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_refs"] = PageReference.objects.filter(work=context["work"])
+        context["person_list"] = PageReference.objects.filter(work=context["work"], lemma__type="p")
+        context["work_list"] = PageReference.objects.filter(work=context["work"], lemma__type="w")
         return context
 
 


### PR DESCRIPTION
See screenshots below for the idea.

- [x] Sort lemma's by type on the work page.
- [x] Hide 'people' and 'work' headings when no lemma's of that type are found.


![Screenshot 2022-02-02 at 12 06 03](https://user-images.githubusercontent.com/77152231/152142510-18d604c6-fafe-4749-93de-49f905aad3f3.png)
![Screenshot 2022-02-02 at 12 06 20](https://user-images.githubusercontent.com/77152231/152142514-d71a54ad-28d8-4bfd-97be-bab2008f18af.png)
