### PR TITLE
Edit work detail view to display mentions.

### DIFF
--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -11,7 +11,6 @@
 {% if work_lemma %}
   <h2>Mentions of <em>{{ work.csl_json.title }}</em></h2>
   {% include '_page_ref_list.html' with page_refs=work_lemma verbose_titles=True only %}
-    </ul>
 {% endif %}
 <h2>Index terms</h2>
 {% regroup page_refs by lemma as lemma_list %}

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -8,6 +8,11 @@
 <h1>{{ work.csl_json.title }}</h1>
 <h2>Reference</h2>
 <p>{{ work.reference | safe }}</p>
+{% if work_lemma %}
+  <h2>Mentions of <em>{{ work.csl_json.title }}</em></h2>
+  {% include '_page_ref_list.html' with page_refs=work_lemma verbose_titles=True only %}
+    </ul>
+{% endif %}
 <h2>Index terms</h2>
 {% regroup page_refs by lemma as lemma_list %}
 <ul class="lemma-refs">

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -20,6 +20,13 @@ class WorkDetailView(DetailView):
     template_name = "work_detail.html"
     context_object_name = "work"
 
+    def _get_work_lemma(self, work: Work):
+    short_title = work.csl_json.get("title-short")  # Geeft None terug als het veld niet bestaat
+    if short_title:
+        return PageReference.objects.filter(lemma__value=short_title, lemma__type="w")
+    else:
+        return PageReference.objects.filter(lemma__value=work.csl_json["title"], lemma__type="w")
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["work_lemma"] = PageReference.objects.filter(lemma__value=context["work"].csl_json["title"], lemma__type="w")

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -29,7 +29,7 @@ class WorkDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["work_lemma"] = PageReference.objects.filter(lemma__value=context["work"].csl_json["title"], lemma__type="w")
+        context["work_lemma"] = self._get_work_lemma(context["work"])
         context["page_refs"] = PageReference.objects.filter(work=context["work"])
         context["person_list"] = PageReference.objects.filter(work=context["work"], lemma__type="p")
         context["work_list"] = PageReference.objects.filter(work=context["work"], lemma__type="w")

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -22,6 +22,7 @@ class WorkDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["work_lemma"] = PageReference.objects.filter(lemma__value=context["work"].csl_json["title"], lemma__type="w")
         context["page_refs"] = PageReference.objects.filter(work=context["work"])
         context["person_list"] = PageReference.objects.filter(work=context["work"], lemma__type="p")
         context["work_list"] = PageReference.objects.filter(work=context["work"], lemma__type="w")

--- a/index/works.yml
+++ b/index/works.yml
@@ -61,6 +61,7 @@ SZ:
     - - '1983'
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
+  short-title: "Die Grundbegriffe der Metaphysik"
   title: "Die Grundbegriffe der Metaphysik: Welt, Endlichkeit, Einsamkeit"
   type: book
   language: german
@@ -167,6 +168,7 @@ ZEG:
   language: german
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
+  short-title: 'Zur Erörterung der Gelassenheit'
   title: 'Zur Erörterung der Gelassenheit: Aus einem Feldweggespräch über das Denken'
   type: chapter
   page: 37-74
@@ -212,6 +214,6 @@ WBPh:
   page: 239-302
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
+  short-title: Vom Wesen und Begriff der Φὐσις
   title: Vom Wesen und Begriff der Φὐσις, Aristoteles, Physik B, 1
   type: chapter
-

--- a/index/works.yml
+++ b/index/works.yml
@@ -61,7 +61,7 @@ SZ:
     - - '1983'
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
-  short-title: "Die Grundbegriffe der Metaphysik"
+  title-short: Die Grundbegriffe der Metaphysik
   title: "Die Grundbegriffe der Metaphysik: Welt, Endlichkeit, Einsamkeit"
   type: book
   language: german
@@ -168,8 +168,8 @@ ZEG:
   language: german
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
-  short-title: 'Zur Erörterung der Gelassenheit'
   title: 'Zur Erörterung der Gelassenheit: Aus einem Feldweggespräch über das Denken'
+  title-short: Zur Erörterung der Gelassenheit
   type: chapter
   page: 37-74
 FW:
@@ -214,6 +214,6 @@ WBPh:
   page: 239-302
   publisher: Vittorio Klostermann
   publisher-place: Frankfurt am Main
-  short-title: Vom Wesen und Begriff der Φὐσις
   title: Vom Wesen und Begriff der Φὐσις, Aristoteles, Physik B, 1
+  title-short: Vom Wesen und Begriff der Φὐσις
   type: chapter


### PR DESCRIPTION
# Add a 'Mentions of _work_' section to the work view.
- Mentions are only displayed if the index contains a lemma which is equal to the work title defined in `works.yml`.
- Makes use of the `_page_ref_list.html` template to render the references, so both the styling and functionality (links) are the same as the main index page.
- Allows for adjustments if works and lemma's are to be more explicitely linked in the future. 

__If lemma is found the work view looks like this:__
![Screenshot of work view when lemma is found in the index.](https://user-images.githubusercontent.com/77152231/163409013-68268feb-fa5a-4731-9599-66b247c7578f.png)

__If lemma is not found the work view looks like this:__
![Screenshot of work view when lemma is not found in the index.](https://user-images.githubusercontent.com/77152231/163409947-ba977861-4f15-4311-8e40-a6995ea859c5.png)


