### PR TITLE
Feature/work url pages

### DIFF
--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -1,3 +1,4 @@
+from turtle import Turtle
 import requests
 from bs4 import BeautifulSoup
 from pyCTS import CTS_URN
@@ -124,6 +125,23 @@ class PageReference(models.Model):
             return f"{self.start}{self.suffix}"
         else:
             return f"{self.start}"
+
+    def refers_to_page(self, page):
+        try:
+            page = int(page)
+        except TypeError:
+            raise TypeError
+        
+        if page >= self.start and page < self.end or page == self.end :
+            return True
+        elif self.suffix == "f" and page == self.start + 1:
+            return True
+        elif self.suffix == "ff" and page == self.start + 2:
+            return True
+        else:
+            return False
+
+    # TODO: Add filter for a range of pages.
 
     class Meta:
         ordering = ["lemma", "work", "start", "end", "suffix"]

--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -132,8 +132,12 @@ class PageReference(models.Model):
         except TypeError:
             raise TypeError
         
-        if page >= self.start and page < self.end or page == self.end :
-            return True
+        if self.end:
+            if page >= self.start and page <= self.end :
+                return True
+        if not self.end and self.start:
+            if page == self.start:
+                return True
         elif self.suffix == "f" and page == self.start + 1:
             return True
         elif self.suffix == "ff" and page == self.start + 2:

--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -1,7 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
 from pyCTS import CTS_URN
-import re
 
 from django.db import models
 from django.conf import settings
@@ -12,8 +11,6 @@ from heidegger_index.constants import LEMMA_TYPES, REF_TYPES
 from heidegger_index.utils import (
     gen_sort_key,
     slugify,
-    REF_REGEX,
-    contains_page,
     contains_page_range,
 )
 

--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -9,9 +9,9 @@ from django_extensions.db.fields import AutoSlugField
 from django.core.validators import URLValidator
 
 from heidegger_index.constants import LEMMA_TYPES, REF_TYPES
-from heidegger_index.utils import gen_sort_key, slugify
+from heidegger_index.utils import gen_sort_key, slugify, REF_REGEX
 
-PAGE_RANGE_REGEX = "^(?P<start>\d{1,4})-?(?P<end>\d{0,4})(?P<suffix>[f]{0,2})$"
+
 
 class Work(models.Model):
     key = models.CharField(max_length=8, unique=True)
@@ -146,12 +146,12 @@ class PageReference(models.Model):
                 return True
             elif self.suffix == "ff" and page == self.start + 2:
                 return True
-        else:
-            return False
+
+        return False
 
     def refers_to_page_range(self, page_range):
         if not type(page_range) == dict:
-            page_range = re.fullmatch(PAGE_RANGE_REGEX, page_range)
+            page_range = re.fullmatch(REF_REGEX, page_range)
 
             if not page_range:
                 raise ValueError("Not a valid page range given.")

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -6,7 +6,9 @@
 {% if not page_filter %}{% include '_export_button.html' with type="work" %}{% endif %}
 {% include '_home_button.html' %}
 
+{% if page_filter %}<a href="{% url 'index:work-detail' work.slug %}">{% endif %}
 {% include 'components/h1.html' with text=work.csl_json.title class="clear-right italic" only %}
+{% if page_filter %}</a>{% endif %}
 
 {% if work.parent %}
 <p class="{{ body_text }}">Appears in <a href="{% url 'index:work-detail' work.parent.slug %}" class="{{ hidden_link_decoration }} italic">{{ work.parent.title }}</a></p>

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -3,7 +3,7 @@
 {% block head_title %}{{ work.title }}{% endblock head_title %}
 
 {% block body %}
-{% include '_export_button.html' with type="work" %}
+{% if not page_filter %}{% include '_export_button.html' with type="work" %}{% endif %}
 {% include '_home_button.html' %}
 
 {% include 'components/h1.html' with text=work.csl_json.title class="clear-right italic" only %}

--- a/heidegger_index/urls.py
+++ b/heidegger_index/urls.py
@@ -9,8 +9,9 @@ namespaced_patterns = (
         path("", index_view, name="home"),
         path("work/<slug>.md", WorkDetailViewMD.as_view(content_type='text/markdown'), name="work-md-export"),
         path("lemma/<slug>.md", LemmaDetailViewMD.as_view(content_type='text/markdown'), name="lemma-md-export"),
-        path("work/<slug>/<int:page>", WorkDetailView.as_view(), name="work-detail-select-pages"),
         path("work/<slug>", WorkDetailView.as_view(), name="work-detail"),
+        path("work/<slug>/<int:page>", WorkDetailView.as_view(), name="work-detail-select-pages"),
+
         re_path(
             r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)$", 
             URNRedirectView.as_view(),

--- a/heidegger_index/urls.py
+++ b/heidegger_index/urls.py
@@ -11,7 +11,6 @@ namespaced_patterns = (
         path("lemma/<slug>.md", LemmaDetailViewMD.as_view(content_type='text/markdown'), name="lemma-md-export"),
         path("work/<slug>", WorkDetailView.as_view(), name="work-detail"),
         path("work/<slug>/<int:page>", WorkDetailView.as_view(), name="work-detail-select-pages"),
-
         re_path(
             r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)$", 
             URNRedirectView.as_view(),

--- a/heidegger_index/urls.py
+++ b/heidegger_index/urls.py
@@ -9,9 +9,10 @@ namespaced_patterns = (
         path("", index_view, name="home"),
         path("work/<slug>.md", WorkDetailViewMD.as_view(content_type='text/markdown'), name="work-md-export"),
         path("lemma/<slug>.md", LemmaDetailViewMD.as_view(content_type='text/markdown'), name="lemma-md-export"),
+        path("work/<slug>/<int:page>", WorkDetailView.as_view(), name="work-detail-select-pages"),
         path("work/<slug>", WorkDetailView.as_view(), name="work-detail"),
         re_path(
-            r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)", 
+            r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)$", 
             URNRedirectView.as_view(),
             name="urn-redirect"
         ),

--- a/heidegger_index/urls.py
+++ b/heidegger_index/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 from django.conf import settings
 
+from heidegger_index.utils import REF_REGEX
 from heidegger_index.views import (
     LemmaDetailView,
     index_view,
@@ -11,21 +12,22 @@ from heidegger_index.views import (
     URNRedirectView,
 )
 
+
 namespaced_patterns = (
     [
         path("", index_view, name="home"),
+        path(
+            "work/<slug:slug>.md",
+            WorkDetailViewMD.as_view(content_type="text/markdown"),
+            name="work-md-export",
+        ),
         path(
             "work/<slug:slug>/",
             include(
                 [
                     path("", WorkDetailView.as_view(), name="work-detail"),
-                    path(
-                        ".md",
-                        WorkDetailViewMD.as_view(content_type="text/markdown"),
-                        name="work-md-export",
-                    ),
                     re_path(
-                        r"^(?P<page_range>(?P<page_start>[0-9]{1,4})-?(?P<page_end>[0-9]{0,4})(?P<suffix>[f]{0,2}))$",
+                        r"(?P<page_range>" + REF_REGEX.pattern + ")",
                         WorkDetailView.as_view(),
                         name="work-detail-select-pages",
                     ),

--- a/heidegger_index/urls.py
+++ b/heidegger_index/urls.py
@@ -2,21 +2,47 @@ from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 from django.conf import settings
 
-from heidegger_index.views import LemmaDetailView, index_view, WorkDetailView, WorkDetailViewMD, LemmaDetailViewMD, URNRedirectView
+from heidegger_index.views import (
+    LemmaDetailView,
+    index_view,
+    WorkDetailView,
+    WorkDetailViewMD,
+    LemmaDetailViewMD,
+    URNRedirectView,
+)
 
 namespaced_patterns = (
     [
         path("", index_view, name="home"),
-        path("work/<slug>.md", WorkDetailViewMD.as_view(content_type='text/markdown'), name="work-md-export"),
-        path("lemma/<slug>.md", LemmaDetailViewMD.as_view(content_type='text/markdown'), name="lemma-md-export"),
-        path("work/<slug>", WorkDetailView.as_view(), name="work-detail"),
-        path("work/<slug>/<int:page>", WorkDetailView.as_view(), name="work-detail-select-pages"),
-        re_path(
-            r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)$", 
-            URNRedirectView.as_view(),
-            name="urn-redirect"
+        path(
+            "work/<slug:slug>/",
+            include(
+                [
+                    path("", WorkDetailView.as_view(), name="work-detail"),
+                    path(
+                        ".md",
+                        WorkDetailViewMD.as_view(content_type="text/markdown"),
+                        name="work-md-export",
+                    ),
+                    re_path(
+                        r"^(?P<page_range>(?P<page_start>[0-9]{1,4})-?(?P<page_end>[0-9]{0,4})(?P<suffix>[f]{0,2}))$",
+                        WorkDetailView.as_view(),
+                        name="work-detail-select-pages",
+                    ),
+                ]
+            ),
         ),
-        path("lemma/<slug>", LemmaDetailView.as_view(), name="lemma-detail"),
+        path("lemma/<slug:slug>", LemmaDetailView.as_view(), name="lemma-detail"),
+        path(
+            "lemma/<slug:slug>.md",
+            LemmaDetailViewMD.as_view(content_type="text/markdown"),
+            name="lemma-md-export",
+        ),
+        re_path(
+            r"^lemma/(?P<urn>urn:cts:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+)$",
+            URNRedirectView.as_view(),
+            name="urn-redirect",
+        ),
     ],
     "index",
 )

--- a/heidegger_index/utils.py
+++ b/heidegger_index/utils.py
@@ -8,6 +8,8 @@ PREFIXES = ["der", "die", "das", "den"]
 
 PREFIX_FILTER = re.compile(rf'^(?:{"|".join(PREFIXES)})\s+')
 
+REF_REGEX = re.compile(r"^(?P<start>\d+)(?:-(?P<end>\d+)|(?P<suffix>f{1,2})\.?)?$")
+
 
 def gen_sort_key(value):
     # Strip surrounding whitespaces

--- a/heidegger_index/utils.py
+++ b/heidegger_index/utils.py
@@ -59,15 +59,15 @@ def match_lemmata(search_term, index, max_l_dist=2, include_search_term=True):
 
 def contains_page(reference: dict, page: int) -> bool:
 
-    if reference["end"]:
-        if page >= reference["start"] and page <= reference["end"]:
+    if reference.get("end"):
+        if page >= reference.get("start") and page <= reference.get("end"):
             return True
-    if not reference["end"] and reference["start"]:
-        if page == reference["start"]:
+    if not reference.get("end") and reference.get("start"):
+        if page == reference.get("start"):
             return True
-        elif reference["suffix"] == "f" and page == reference["start"] + 1:
+        elif reference.get("suffix") == "f" and page == reference.get("start") + 1:
             return True
-        elif reference["suffix"] == "ff" and page == reference["start"] + 2:
+        elif reference.get("suffix") == "ff" and page == reference.get("start") + 2:
             return True
 
     return False
@@ -80,14 +80,14 @@ def contains_page_range(reference: dict, page_range) -> bool:
         if not page_range:
             raise ValueError("Not a valid page range given.")
 
-    page_start = int(page_range["start"])
+    page_start = int(page_range.get("start"))
 
-    if not page_range["end"] and page_range["suffix"]:
-        page_end = int(page_range["start"]) + len(page_range["suffix"])
-    elif not page_range["end"] and not page_range["suffix"]:
+    if not page_range.get("end") and page_range.get("suffix"):
+        page_end = int(page_range["start"]) + len(page_range.get("suffix"))
+    elif not page_range.get("end") and not page_range.get("suffix"):
         page_end = int(page_range["start"])
     else:
-        page_end = int(page_range["end"])
+        page_end = int(page_range.get("end"))
     for i in range(page_start, page_end + 1):
         if contains_page(reference, i):
             return True

--- a/heidegger_index/utils.py
+++ b/heidegger_index/utils.py
@@ -57,6 +57,46 @@ def match_lemmata(search_term, index, max_l_dist=2, include_search_term=True):
     return matches
 
 
+def contains_page(reference: dict, page: int) -> bool:
+
+    if reference["end"]:
+        if page >= reference["start"] and page <= reference["end"]:
+            return True
+    if not reference["end"] and reference["start"]:
+        if page == reference["start"]:
+            return True
+        elif reference["suffix"] == "f" and page == reference["start"] + 1:
+            return True
+        elif reference["suffix"] == "ff" and page == reference["start"] + 2:
+            return True
+
+    return False
+
+
+def contains_page_range(reference: dict, page_range) -> bool:
+    if not type(page_range) == dict:
+        page_range = re.fullmatch(REF_REGEX, page_range)
+
+        if not page_range:
+            raise ValueError("Not a valid page range given.")
+
+    page_start = int(page_range["start"])
+
+    if not page_range["end"] and page_range["suffix"]:
+        page_end = int(page_range["start"]) + len(page_range["suffix"])
+    elif not page_range["end"] and not page_range["suffix"]:
+        page_end = int(page_range["start"])
+    else:
+        page_end = int(page_range["end"])
+    for i in range(page_start, page_end + 1):
+        if contains_page(reference, i):
+            return True
+        else:
+            continue
+
+    return False
+
+
 def slugify(value):
     """Slugify function extended with `unidecode` for better unicode representation"""
     return _slugify(unidecode(value))

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -62,16 +62,18 @@ class WorkDetailView(DetailView):
         try:
             page_refs_with_page = []
             for ref in PageReference.objects.filter(
-                    work__in=[work, *work.children.all()]
-                ):
-                if ref.refers_to_page(self.kwargs["page"]):
+                work__in=[work, *work.children.all()]
+            ):
+                if ref.refers_to_page_range(self.kwargs["page_range"]):
                     page_refs_with_page.append(ref.id)
-            
+
             context["page_filter"] = True
             page_refs = PageReference.objects.filter(id__in=page_refs_with_page)
         except KeyError:
             context["page_filter"] = False
-            page_refs = PageReference.objects.filter(work__in=[work, *work.children.all()])
+            page_refs = PageReference.objects.filter(
+                work__in=[work, *work.children.all()]
+            )
         context["term_list"] = page_refs.filter(lemma__type=None)
         context["person_list"] = page_refs.filter(lemma__type="p")
         context["work_list"] = page_refs.filter(lemma__type="w")

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -58,9 +58,11 @@ class WorkDetailView(DetailView):
             pass
         else:
             context["work_lemma"] = work_lemma
-
-        page_refs = PageReference.objects.filter(work__in=[work, *work.children.all()])
-        context["term_list"] = page_refs.filter(lemma__type=None) | page_refs.filter(lemma__type="g")
+        try:
+            page_refs = PageReference.objects.filter(refers_to_page(self.kwargs['page']), work__in=[work, *work.children.all()])
+        except:
+            page_refs = PageReference.objects.filter(work__in=[work, *work.children.all()])
+        context["term_list"] = page_refs.filter(lemma__type=None)
         context["person_list"] = page_refs.filter(lemma__type="p")
         context["work_list"] = page_refs.filter(lemma__type="w")
         return context

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -67,8 +67,10 @@ class WorkDetailView(DetailView):
                 if ref.refers_to_page(self.kwargs["page"]):
                     page_refs_with_page.append(ref.id)
             
+            context["page_filter"] = True
             page_refs = PageReference.objects.filter(id__in=page_refs_with_page)
         except KeyError:
+            context["page_filter"] = False
             page_refs = PageReference.objects.filter(work__in=[work, *work.children.all()])
         context["term_list"] = page_refs.filter(lemma__type=None)
         context["person_list"] = page_refs.filter(lemma__type="p")

--- a/heidegger_index/views.py
+++ b/heidegger_index/views.py
@@ -4,9 +4,6 @@ from django.views.generic.detail import DetailView
 from django.shortcuts import redirect
 from django.conf import settings
 
-import requests
-
-
 from heidegger_index.models import Lemma, PageReference, Work, get_alphabet
 
 

--- a/index/__init__.py
+++ b/index/__init__.py
@@ -33,8 +33,16 @@ from heidegger_index.constants import LEMMA_TYPES, REF_TYPES, RELATION_TYPES
     default=False,
     help="Convert lemma from betacode to unicode",
 )
-def click_add_ref(lemma, work, ref, lemma_type, ref_type, betacode):
-    add_ref(lemma, work, ref, lemma_type, ref_type, betacode)
+@click.option(
+    "-f",
+    "--force",
+    "force",
+    is_flag=True,
+    default=False,
+    help="Force reference to be added to lemma",
+)
+def click_add_ref(lemma, work, ref, lemma_type, ref_type, betacode, force):
+    add_ref(lemma, work, ref, lemma_type, ref_type, betacode, force)
 
 
 @click.command()

--- a/index/heidegger-index.yml
+++ b/index/heidegger-index.yml
@@ -2850,6 +2850,7 @@ als:
     - start: 487
     - end: 425
       start: 423
+    - start: 484
 als solches:
   references:
     GA 29/30:

--- a/index/index.py
+++ b/index/index.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from itertools import combinations
 from pyCTS import CTS_URN
 
-from heidegger_index.utils import match_lemmata
+from heidegger_index.utils import match_lemmata, REF_REGEX
 from heidegger_index.constants import (
     LEMMA_TYPES,
     PERSON,
@@ -32,7 +32,6 @@ CITEPROC_ENDPOINT = "https://labs.brill.com/citeproc"
 
 yaml.warnings({"YAMLLoadWarning": False})
 
-REF_REGEX = re.compile(r"^(?P<start>\d+)(?:-(?P<end>\d+)|(?P<suffix>f{1,2})\.?)?$")
 REF_INTFIELDS = {"start", "end"}
 
 

--- a/index/index.py
+++ b/index/index.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from itertools import combinations
 from pyCTS import CTS_URN
 
-from heidegger_index.utils import match_lemmata, REF_REGEX
+from heidegger_index.utils import match_lemmata, contains_page_range, REF_REGEX
 from heidegger_index.constants import (
     LEMMA_TYPES,
     PERSON,
@@ -35,7 +35,9 @@ yaml.warnings({"YAMLLoadWarning": False})
 REF_INTFIELDS = {"start", "end"}
 
 
-def add_ref(lemma, work, ref, lemma_type=None, ref_type=None, betacode=False):
+def add_ref(
+    lemma, work, ref, lemma_type=None, ref_type=None, betacode=False, force=False
+):
 
     if isinstance(ref, list):
         # Allow ref to be a list, call add_ref for each item and terminate function
@@ -105,19 +107,40 @@ def add_ref(lemma, work, ref, lemma_type=None, ref_type=None, betacode=False):
         if refs.get(work):
             # Only appends reference if it does not already exist in index.
             r = refs[work]
-            # Checks whether exact reference is already in the index.
-            if ref_dict in r:
-                raise click.BadParameter(f"Reference already exists for this lemma.")
-            # UNCOMMENT THIS IF YOU WANT TO PREVENT NEW REFERENCES BEING ADDED IF "WHOLE"
-            # IS TRUE.
-            # Checks whether the work as a whole is not already a reference for the lemma.
-            #
-            # elif {"whole": True} in r:
-            #     raise click.BadParameter(
-            #         f"This work as a whole is already a reference for this lemma."
-            #     )
-            else:
-                refs[work].append(ref_dict)
+
+            if not force:
+                # Checks whether exact reference is already in the index.
+                if ref_dict in r:
+                    raise click.BadParameter(
+                        f"Reference already exists for this lemma."
+                        f"\nUse option '--force' to ignore this warning and force adding '{ref}' to '{lemma}'."
+                        f"\nThis will lead to duplicate references in the index."
+                    )
+                # UNCOMMENT THIS IF YOU WANT TO PREVENT NEW REFERENCES BEING ADDED IF "WHOLE"
+                # IS TRUE.
+                # Checks whether the work as a whole is not already a reference for the lemma.
+                #
+                # elif {"whole": True} in r:
+                #     raise click.BadParameter(
+                #         f"This work as a whole is already a reference for this lemma."
+                #     )
+
+                else:
+                    # Check whether pages are allready all in the index
+                    for i in r:
+                        if contains_page_range(i, ref_dict):
+                            if i.get("end"):
+                                dash = "-"
+                            else:
+                                dash = ""
+                            raise click.BadParameter(
+                                f"Reference '{i.get('start')}{dash}{i.get('end', '')}{i.get('suffix', '')}' already exists for this lemma."
+                                f"\nUse option '--force' to ignore this warning and force adding '{ref}' to '{lemma}'."
+                                f"\nThis will lead to pages occuring multiple times in seperate references."
+                            )
+
+            refs[work].append(ref_dict)
+
         else:
             refs[work] = [ref_dict]
             if lemma_type:


### PR DESCRIPTION
Maakt het mogelijk om de index te filteren door paginanummers aan de URL toe te voegen.

https://user-images.githubusercontent.com/77152231/212060836-550c985d-0f4b-404d-acd6-d4fb8b6f7b85.mov

## Veranderingen

- Wanneer je een `work page` bekijkt worden de referenties gefiltered indien er paginanummers aan de URL toegevoegd worden.
- Ondersteund zowel enkele paginanummers als een bereik, inclusief suffix. Dus zowel `45-112`, `405` als `33ff` zijn toegestaan.
- De export-knop verdwijnt indien je de referenties filtert aangezien er momenteel enkel een export van de gehele `work page` gemaakt kan worden.
- De kop (de titel van het werk) wordt een link naar de `work page` indien de referenties gefiltered worden.

## Waarom?

Het is nu eenvoudiger te controleren of pagina's uit werken al een keer toegevoegd zijn in de index. 

