### PR TITLE
Add numeric unicode support

### DIFF
--- a/heidegger_index/models.py
+++ b/heidegger_index/models.py
@@ -69,10 +69,7 @@ class Lemma(models.Model):
     perseus_content = models.TextField(null=True)
 
     gnd = models.CharField(
-        null=True,
-        unique=True,
-        max_length=11,
-        validators=[validate_gnd]
+        null=True, unique=True, max_length=11, validators=[validate_gnd]
     )
     sort_key = models.CharField(max_length=100, null=True, unique=True)
     first_letter = models.CharField(max_length=1, null=True)
@@ -91,7 +88,10 @@ class Lemma(models.Model):
 
     def create_sort_key(self):
         self.sort_key = gen_sort_key(self.value)
-        self.first_letter = self.sort_key and self.sort_key[0].upper() or ""
+        first_letter = self.sort_key[0].upper() if self.sort_key else ""
+        if ord("0") <= ord(first_letter) <= ord("9"):
+            first_letter = "#"
+        self.first_letter = first_letter
 
     def save(self, *args, **kwargs):
         if not self.sort_key:

--- a/heidegger_index/templates/_toc.html
+++ b/heidegger_index/templates/_toc.html
@@ -1,5 +1,5 @@
 <div class="sticky w-screen mb-10 -ml-4 overflow-x-auto md:ml-0 md:w-auto top-6">
-  <div class="flex items-center justify-between gap-1 px-3 py-2 mx-4 mb-2 text-3xl rounded-md shadow shrink-0 md:mx-0 md:w-full bg-slate-100 dark:bg-slate-600 dark:text-white w-fit">
+  <div class="flex items-center justify-between gap-[2px] px-3 py-2 mx-4 mb-2 text-3xl rounded-md shadow shrink-0 md:mx-0 md:w-full bg-slate-100 dark:bg-slate-600 dark:text-white w-fit">
 
   {% if alphabet.pre %}
   {% for letter in alphabet.pre %}
@@ -7,7 +7,7 @@
   {% endfor %}
   {% endif %}
 
-  <div class="flex gap-1 rounded-md bg-slate-200 dark:bg-slate-500">
+  <div class="flex gap-[2px] rounded-md bg-slate-200 dark:bg-slate-500">
   {% for letter in alphabet.selected %}
     <button onClick="scrollToWithOffset('{{ letter }}')" class="px-1 transition-colors rounded-md hover:bg-slate-300 dark:hover:bg-slate-400">{{ letter }}</button>
   {% endfor %}

--- a/heidegger_index/utils.py
+++ b/heidegger_index/utils.py
@@ -10,10 +10,86 @@ PREFIX_FILTER = re.compile(rf'^(?:{"|".join(PREFIXES)})\s+')
 
 REF_REGEX = re.compile(r"^(?P<start>\d+)(?:-(?P<end>\d+)|(?P<suffix>f{1,2})\.?)?$")
 
+# This is the NUMBER FORM unicode block
+NUMERIC_UNICODE_VALUES = {
+    188: 0.25,
+    189: 0.5,
+    190: 0.75,
+    8528: 0.142857,
+    8529: 0.111,
+    8530: 0.1,
+    8531: 0.333,
+    8532: 0.666,
+    8533: 0.2,
+    8534: 0.4,
+    8535: 0.6,
+    8536: 0.8,
+    8537: 0.166,
+    8538: 0.833,
+    8539: 0.125,
+    8540: 0.375,
+    8541: 0.625,
+    8542: 0.875,
+    8543: 1,
+    8544: 1,
+    8545: 2,
+    8546: 3,
+    8547: 4,
+    8548: 5,
+    8549: 6,
+    8550: 7,
+    8551: 8,
+    8552: 9,
+    8553: 10,
+    8554: 11,
+    8555: 12,
+    8556: 50,
+    8557: 100,
+    8558: 500,
+    8559: 1000,
+    8560: 1,
+    8561: 2,
+    8562: 3,
+    8563: 4,
+    8564: 5,
+    8565: 6,
+    8566: 7,
+    8567: 8,
+    8568: 9,
+    8569: 10,
+    8570: 11,
+    8571: 12,
+    8572: 50,
+    8573: 100,
+    8574: 500,
+    8575: 1000,
+    8576: 1000,
+    8577: 5000,
+    8578: 10000,
+    8579: 100,
+    8580: 100,
+    8581: 6,
+    8582: 50,
+    8583: 50000,
+    8584: 100000,
+    8585: 0,
+    8586: 10,
+    8587: 11,
+}
 
-def gen_sort_key(value):
+
+def convert_numeric_unicode(value: str) -> str:
+    new_value = ""
+    for char in value:
+        new_value += str(NUMERIC_UNICODE_VALUES.get(ord(char), char))
+    return new_value
+
+
+def gen_sort_key(value: str) -> str:
     # Strip surrounding whitespaces
     value = value.strip()
+    # Convert numeric unicode to value
+    value = convert_numeric_unicode(value)
     # Normalize unicode
     value = unidecode(value)
     # Convert to lowercase

--- a/tailwind/dist/styles.css
+++ b/tailwind/dist/styles.css
@@ -1585,6 +1585,10 @@ video {
   width: 1.5rem;
 }
 
+.w-12 {
+  width: 3rem;
+}
+
 .w-screen {
   width: 100vw;
 }
@@ -1593,14 +1597,6 @@ video {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-}
-
-.w-8 {
-  width: 2rem;
-}
-
-.w-12 {
-  width: 3rem;
 }
 
 .max-w-3xl {
@@ -1647,8 +1643,8 @@ video {
   justify-content: space-between;
 }
 
-.gap-1 {
-  gap: 0.25rem;
+.gap-\[4px\] {
+  gap: 4px;
 }
 
 .gap-8 {
@@ -1657,6 +1653,10 @@ video {
 
 .gap-4 {
   gap: 1rem;
+}
+
+.gap-\[2px\] {
+  gap: 2px;
 }
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {


### PR DESCRIPTION
Betere afhandeling van numerieke karakters in onze index:

* Voor het genereren van de `sort_key` worden numerieke unicode-karakters als bijv. de Romeinse cijfers in hun waarde omgezet.
* Alle lemma's die met een getal beginnen worden gegroepeerd onder '#', en gesorteerd naar waarde.

Zie voorbeeld in de schermafbeelding hieronder. Onderliggende data:

| value | sort_key | slug |
|---|---|---|
| Ⅰ Cor. 11. 7 | 00001 cor. 00011. 00007 | i-cor-11-7 |
| Ⅱ Cor. 3. 18 | 00002 cor. 00003. 00018 | ii-cor-3-18 |
|  4 Esra 7. 12 | 00004 esra 00007. 00012 | 4-esra-7-12 |

<img width="925" alt="Scherm­afbeelding 2023-02-26 om 21 56 27" src="https://user-images.githubusercontent.com/32297879/221437135-92e7c8ef-3f74-4391-b86f-4919e89f9415.png">
