### PR TITLE
Add locale support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 build/
 *.egg-info
 staticfiles/
+*.mo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 python manage.py migrate
 python manage.py populate_index
 python manage.py collectstatic --no-input
+python manage.py compilemessages
 gunicorn heidegger_index.wsgi:application --bind 0.0.0.0:$1

--- a/heidegger_index/management/commands/compilemessages.py
+++ b/heidegger_index/management/commands/compilemessages.py
@@ -1,0 +1,11 @@
+from django.core.management.commands import compilemessages
+from django.conf import settings
+
+
+# compilemessages command with some default arguments
+class Command(compilemessages.Command):
+    def handle(self, *args, **options):
+        locale = options.pop("locale", [])
+        super(Command, self).handle(
+            *args, **options, locale=[*locale, *settings.SUPPORTED_LOCALES]
+        )

--- a/heidegger_index/management/commands/makemessages.py
+++ b/heidegger_index/management/commands/makemessages.py
@@ -1,0 +1,15 @@
+from django.core.management.commands import makemessages
+from django.conf import settings
+
+
+# makemessages command with some default arguments
+class Command(makemessages.Command):
+    def handle(self, *args, **options):
+        locale = options.pop("locale", [])
+        ignore_patterns = options.pop("ignore_patterns", [])
+        super(Command, self).handle(
+            *args,
+            **options,
+            locale=[*locale, *settings.SUPPORTED_LOCALES],
+            ignore_patterns=[*ignore_patterns, *settings.LOCALE_IGNORE_PATTERNS]
+        )

--- a/heidegger_index/settings.py
+++ b/heidegger_index/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -108,6 +109,9 @@ LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 
 USE_I18N = True
+SUPPORTED_LOCALES = ["nl"]
+LOCALE_PATHS = [BASE_DIR / "locales"]
+LOCALE_IGNORE_PATTERNS = ["venv"]
 
 USE_L10N = True
 

--- a/heidegger_index/templates/_site_base.html
+++ b/heidegger_index/templates/_site_base.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-{% load static %}
+{% load static i18n %}
 <html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block full_head_title %}{% block head_title %}{% endblock %} – Heidegger index{% endblock %}</title>
+    <title>{% block full_head_title %}{% block head_title %}{% endblock %} – {% translate "Heidegger index" %}{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'styles.css' %}">
     <link rel="stylesheet" href="{% static 'css/fonts.css' %}">
     <link rel="stylesheet" href="{% static 'css/phosphor-icons.css' %}">

--- a/heidegger_index/templates/index.html
+++ b/heidegger_index/templates/index.html
@@ -1,18 +1,21 @@
 {% extends '_site_base.html' %}
+{% load i18n %}
 
-{% block full_head_title %}Heidegger index{% endblock full_head_title %}
+{% get_available_languages as languages %}
+
+{% block full_head_title %}{% translate "Heidegger index" %}{% endblock full_head_title %}
 
 {% block body %}
-<h1 class="py-4 text-5xl font-bold dark:text-white">Heidegger index</h1>
+<h1 class="py-4 text-5xl font-bold dark:text-white">{% translate "Heidegger index" %}</h1>
 <p class="pb-12 {{ body_text }}">
-  Managed by: <a href="https://github.com/andredelft" target="_blank" rel="noopener noreferrer" class="{{ link_decoration }}">André van Delft</a> &amp; <a href="https://github.com/johannesdewit" target="_blank" rel="noopener noreferrer" class="{{ link_decoration }}">Johannes de Wit</a>
+  {% translate "Managed by" %}: <a href="https://github.com/andredelft" target="_blank" rel="noopener noreferrer" class="{{ link_decoration }}">André van Delft</a> &amp; <a href="https://github.com/johannesdewit" target="_blank" rel="noopener noreferrer" class="{{ link_decoration }}">Johannes de Wit</a>
 </p>
 
 {% include '_toc.html' %}
 
 {% if alphabet.pre %}
   <div>
-  <a href="{% url 'index:home' %}?start={{ alphabet.pre|last }}#{{ alphabet.pre|last }}" class="{{ hidden_link_decoration }}">← Previous</a>
+  <a href="{% url 'index:home' %}?start={{ alphabet.pre|last }}#{{ alphabet.pre|last }}" class="{{ hidden_link_decoration }}">← {% translate "Previous" %}</a>
   </div>
 {% endif %}
 
@@ -43,11 +46,11 @@
 
 {% if alphabet.post %}
   <div class="pt-8">
-    <a href="{% url 'index:home' %}?start={{ alphabet.post|first }}#{{ alphabet.post|first }}" class="{{ hidden_link_decoration }}">Next →</a>
+    <a href="{% url 'index:home' %}?start={{ alphabet.post|first }}#{{ alphabet.post|first }}" class="{{ hidden_link_decoration }}">{% translate "Next" %} →</a>
   </div>
 {% endif %}
 
-<h2 class="mt-16 mb-8 text-3xl font-bold dark:text-white scroll-mt-24" id="bibliography">Bibliography</h2>
+<h2 class="mt-16 mb-8 text-3xl font-bold dark:text-white scroll-mt-24" id="bibliography">{% translate "Bibliography" %}</h2>
 <div class="flex flex-col gap-8">
   {% for work in works %}
   {% if work.reference %}

--- a/heidegger_index/templates/lemma_detail.html
+++ b/heidegger_index/templates/lemma_detail.html
@@ -1,4 +1,5 @@
 {% extends '_site_base.html' %}
+{% load i18n %}
 
 {% block head_title %}{{ lemma.value }}{% endblock head_title %}
 
@@ -10,7 +11,7 @@
 
 {% if lemma.type == "w" and lemma.author %}
 <div class="pb-8 pl-4 {{ body_text }}">
-  Author: <a href="{% url 'index:lemma-detail' lemma.author.slug %}" class="{{ hidden_link_decoration }}">{{ lemma.author }}</a>
+  {% translate "Author" %}: <a href="{% url 'index:lemma-detail' lemma.author.slug %}" class="{{ hidden_link_decoration }}">{{ lemma.author }}</a>
 </div>
 {% endif %}
 
@@ -20,7 +21,7 @@
     {{ lemma.perseus_content }}
   </p>
   <p class="text-lg text-right">
-  Source: <a 
+  {% translate "Source" %}: <a 
     href="https://scaife.perseus.org/reader/{{ lemma.urn | safe }}" 
     title="Read full text of {{ lemma.value }} on Perseus"
     target="_blank" rel="noopener noreferrer"
@@ -68,9 +69,9 @@
   class="{{ hidden_link_decoration }}"
   >
   {% if lemma.type == "w" %}
-  Read full text of <em>{{ lemma.value }}</em> on <cite>Perseus Digital Library</cite>
+  {% translate "Read full text of" %} <em>{{ lemma.value }}</em> {% translate "on" %} <cite>Perseus Digital Library</cite>
   {% elif lemma.type == "p" %}
-  Read works of {{ lemma.value }} on <cite>Perseus Digital Library</cite>
+  {% translate "Read works of" %} {{ lemma.value }} {% translate "on" %} <cite>Perseus Digital Library</cite>
   {% endif %}
   </a>
   </p>

--- a/heidegger_index/templates/work_detail.html
+++ b/heidegger_index/templates/work_detail.html
@@ -1,4 +1,5 @@
 {% extends '_site_base.html' %}
+{% load i18n %}
 
 {% block head_title %}{{ work.title }}{% endblock head_title %}
 
@@ -16,7 +17,7 @@
 
 
 {% if work.parent %}
-<p class="{{ body_text }}">Appears in <a href="{% url 'index:work-detail' work.parent.slug %}" class="{{ hidden_link_decoration }} italic">{{ work.parent.title }}</a></p>
+<p class="{{ body_text }}">{% translate "Appears in" %} <a href="{% url 'index:work-detail' work.parent.slug %}" class="{{ hidden_link_decoration }} italic">{{ work.parent.title }}</a></p>
 {% endif %}
 
 {% if work.children.all %}

--- a/locales/nl/LC_MESSAGES/django.po
+++ b/locales/nl/LC_MESSAGES/django.po
@@ -1,0 +1,66 @@
+# Nederlandse vertaling.
+# Copyright (C) 2023 André van Delft & Johannes de Wit
+# This file is distributed under the MIT license.
+# André van Delft <andrevandelft@outlook.com>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-19 08:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: André van Delft <andrevandelft@outlook.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: heidegger_index/templates/_site_base.html:8
+#: heidegger_index/templates/index.html:6
+#: heidegger_index/templates/index.html:9
+msgid "Heidegger index"
+msgstr "Heidegger-index"
+
+#: heidegger_index/templates/index.html:11
+msgid "Managed by"
+msgstr "Beheerd door"
+
+#: heidegger_index/templates/index.html:18
+msgid "Previous"
+msgstr "Vorige"
+
+#: heidegger_index/templates/index.html:49
+msgid "Next"
+msgstr "Volgende"
+
+#: heidegger_index/templates/index.html:53
+msgid "Bibliography"
+msgstr "Bibliografie"
+
+#: heidegger_index/templates/lemma_detail.html:14
+msgid "Author"
+msgstr "Auteur"
+
+#: heidegger_index/templates/lemma_detail.html:24
+msgid "Source"
+msgstr "Bron"
+
+#: heidegger_index/templates/lemma_detail.html:72
+msgid "Read full text of"
+msgstr "Lees de volledige tekst van"
+
+#: heidegger_index/templates/lemma_detail.html:72
+#: heidegger_index/templates/lemma_detail.html:74
+msgid "on"
+msgstr "in de"
+
+#: heidegger_index/templates/lemma_detail.html:74
+msgid "Read works of"
+msgstr "Lees de werken van"
+
+#: heidegger_index/templates/work_detail.html:20
+msgid "Appears in"
+msgstr "Verschenen in"


### PR DESCRIPTION
NL locale support toegevoegd, die door de `LocaleMiddleware` automatisch wordt toegevoegd op basis van de browser voorkeuren (zie ook https://docs.djangoproject.com/en/4.2/topics/i18n/translation/#how-django-discovers-language-preference).

Ik heb ervoor gekozen om de gecompilede *.mo bestanden te ignoren, en op de server het `compilemessages` bestand te draaien, zodat er geen binaries opgeslagen worden in deze repo. Als je lokaal de vertalingen wil zien, moet je dus nog even `python manage.py compilemessages` draaien.

Verder heb ik wat default arguments toegevoegd aan de `makemessages` en `compilemessages` commands, zodat standaard alleen de NL locales gecreëerd worden (nieuwe zijn toe te voegen via de settings.py) en de `venv` folder genegeerd wordt.