### PR TITLE
Better parsing of Perseus XML

### DIFF
--- a/heidegger_index/passage.py
+++ b/heidegger_index/passage.py
@@ -1,0 +1,32 @@
+import requests
+from bs4 import BeautifulSoup
+from pyCTS import CTS_URN
+
+
+STRIP_TAGS = ["bibl", "label", "note"]
+
+
+def strip_tei_xml(xml: str):
+    body = BeautifulSoup(xml, "xml").TEI
+
+    if not body:
+        return
+
+    for el in body(STRIP_TAGS):
+        el.decompose()
+
+    return body.text.strip()
+
+
+def get_perseus_passage(urn: str):
+    if not CTS_URN(urn).passage_component:
+        return
+
+    api_url = f"https://scaife-cts.perseus.org/api/cts?request=GetPassage&urn={urn}"
+
+    try:
+        r = requests.get(api_url)
+    except requests.HTTPError:
+        return
+
+    return strip_tei_xml(r.text)

--- a/heidegger_index/templates/components/_perseus_content.html
+++ b/heidegger_index/templates/components/_perseus_content.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+
+<blockquote>
+  {{ lemma.perseus_content|truncatewords:100 }} 
+  ({% translate "Bron" %}: <a href="https://scaife.perseus.org/reader/{{ lemma.urn | safe }}" target="_blank"><cite>Perseus Digital Library</cite></a>)
+</blockquote>

--- a/heidegger_index/templates/lemma_detail.html
+++ b/heidegger_index/templates/lemma_detail.html
@@ -19,12 +19,8 @@
 </div>
 {% endif %}
 
-{% if lemma.type == "w" and lemma.perseus_content %}
-<blockquote>
-  {{ lemma.perseus_content }} 
-  ({% translate "Bron" %}: 
-  <a href="https://scaife.perseus.org/reader/{{ lemma.urn | safe }}" title="Read full text of {{ lemma.value }} on Perseus" target="_blank"><cite>Perseus Digital Library</cite></a>)
-</blockquote>
+{% if lemma.perseus_content %}
+  {% include "components/_perseus_content.html" %}
 {% endif %}
 
 {% if lemma.description %}
@@ -35,6 +31,10 @@
 
 {% for child in children %}
 <h2 id="{{ child.slug }}">{{ child }}</h2>
+  {% if child.perseus_content %}
+    {% include "components/_perseus_content.html" with lemma=child %}
+  {% endif %}
+
   {% if child.description %}
     {{ child.description | safe }}
   {% endif %}

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,3 +20,4 @@ aenum==3.*
 django-compressor==4.*
 django-libsass==0.*
 python-decouple==3.*
+lxml==5.*


### PR DESCRIPTION
@johannesdewit Ik heb de oplossing uitgewerkt om de Perseus XML te parsen, en daarbij enkele tags te strippen ('label', 'bibl', en 'note'). Ik geloof dat dat nu redelijk goed gaat, in ieder geval voor zowel de Odyssee als de fragmenten van Heraclitus. Ook heb ik het filter [`truncatewords`](https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#truncatewords) gebruikt om lange teksten (zoals de odyssee) af te kappen bij 100 worden (via de link naar Perseus kan dan doorgelezen worden). En ik heb deze preview ook bij child lemma's toegepast, dat was nog niet zo.

Zie hieronder een screenshot van de Odyssee. Benieuwd wat je van deze oplossing vindt!

![Capture-2024-01-24-111837](https://github.com/andredelft/heidegger-index/assets/32297879/ae53168a-ab71-4daf-af32-8555308ef3c5)