### PR TITLE
Fix #53: Sort refs by start when displaying by lemma

### DIFF
--- a/heidegger_index/templates/components/ref_list/_group_by_lemma.html
+++ b/heidegger_index/templates/components/ref_list/_group_by_lemma.html
@@ -3,7 +3,7 @@
   {% for lemma, page_ref_list in lemma_groups %}
     <li>
       <a href="{% url 'lemma-detail' lemma.slug %}">{{ lemma.display }}</a>:
-      {{ page_ref_list|join:', ' }}
+      {{ page_ref_list|dictsort:"start"|join:', ' }}
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Fix #53 